### PR TITLE
add keyword lookup by PowerShell Get-Help

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -20,6 +20,7 @@ Changes from vim-ps1
 * Renamed filetype from ps1 to powershell
 * Replaced indentation script with script from [Lior Elia][5].
 * Added compiler settings, so a powershell script can be parsed with `:make`
+* Added a program to look up keywords by hitting the `K` key, see `:help K`
 
 Thanks to Lior Elia for the indentation script and Enno Nagel for the
 suggestions on how to setup errorformat and makeprg in a filetype plugin. See
@@ -28,7 +29,7 @@ suggestions on how to setup errorformat and makeprg in a filetype plugin. See
 Original Readme
 ---------------
 
-If you are a Windows PowerShell user who uses Vim or Gvim for editing scripts, 
+If you are a Windows PowerShell user who uses Vim or Gvim for editing scripts,
 then this plugin is for you.
 
 It provides nice syntax coloring and indenting for PowerShell (.ps1) files,
@@ -55,7 +56,7 @@ Or even better, use [pathogen.vim][1] and simply pull it in like this:
 Folding
 -------
 
-The powershell syntax file provides syntax folding for script blocks and digital 
+The powershell syntax file provides syntax folding for script blocks and digital
 signatures in scripts.
 
 When 'foldmethod' is set to "syntax" then function script blocks will be

--- a/ftplugin/powershell.vim
+++ b/ftplugin/powershell.vim
@@ -1,4 +1,13 @@
 " Vim filetype plugin file
+if &compatible || exists('g:loaded_powershell')
+    finish
+endif
+
+function! s:powershell()
+    
+endfunction!
+
+let g:loaded_powershell = 1
 " Language:           Windows PowerShell
 " Maintainer:         Peter Provost <peter@provost.org>
 " Updated:            Jesse Harris <jesse@zigford.org>
@@ -30,7 +39,25 @@ if has("gui_win32")
 				\ "All Files (*.*)\t*.*\n"
 endif
 
+" Look up keywords by Get-Help:
+" check for PowerShell Core in Windows, Linux or MacOS
+if executable('pwsh') | let s:pwsh_cmd = 'pwsh'
+" on Windows Subsystem for Linux, check for PowerShell Core in Windows
+elseif exists('$WSLENV') && executable('pwsh.exe') | let s:pwsh_cmd = 'pwsh.exe'
+" check for PowerShell <= 5.1 in Windows
+elseif executable('powershell.exe') | let s:pwsh_cmd = 'powershell.exe'
+endif
+
+if exists('s:pwsh_cmd')
+  if !has('gui_running') && executable('less')
+    command! -buffer -nargs=1 GetHelp silent exe '!' . s:pwsh_cmd . ' -NoLogo -NoProfile -NonInteractive -ExecutionPolicy RemoteSigned -Command Get-Help -Full "<args>" | ' . (has('unix') ? 'LESS= less' : 'less') | redraw!
+    setlocal keywordprg=:GetHelp
+  else
+    let &l:keywordprg = (has('terminal') ? ':term ' : '') . s:pwsh_cmd . ' -NoLogo -NoProfile -NonInteractive -ExecutionPolicy RemoteSigned -Command Get-Help -Full'
+  endif
+endif
+
 " Undo the stuff we changed
-let b:undo_ftplugin = "setlocal tw< cms< fo<" .
+let b:undo_ftplugin = "setlocal tw< cms< fo< iskeyword< keywordprg<" .
 			\ " | unlet! b:browsefilter"
 


### PR DESCRIPTION
If less is installed and Terminal Vim is used, use that. Otherwise, on recent Versions of Vim (>= 8.0), the :term command is used

     let &l:keywordprg=':term pwsh -NoLogo -NoProfile -NonInteractive -ExecutionPolicy RemoteSigned -Command Get-Help -Full'

Finally, use Vim's default pager.